### PR TITLE
feat: add Laravel Zero 12 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     ],
     "require": {
         "php": "^8.2",
-        "laravel-zero/framework": "^11.0",
-        "illuminate/console": "^11.0"
+        "laravel-zero/framework": "^11.0|^12.0",
+        "illuminate/console": "^11.0|^12.0"
     },
     "require-dev": {
         "laravel/pint": "^1.18",


### PR DESCRIPTION
## Description

This PR adds support for Laravel Zero 12 while maintaining backward compatibility with Laravel Zero 11.

## Changes
- Updated `laravel-zero/framework` constraint from `^11.0` to `^11.0|^12.0`
- Updated `illuminate/console` constraint from `^11.0` to `^11.0|^12.0`

## Why?
Projects using Laravel Zero 12 (like THE SHIT) cannot currently use conduit-interfaces due to the version constraint. This change enables compatibility with both Laravel Zero 11 and 12.

## Testing
- Ran `composer update` successfully with the new constraints
- No code changes required, only dependency constraints updated

## Breaking Changes
None - this maintains backward compatibility with Laravel Zero 11 projects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version requirements to support both version 11 and 12 of key packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->